### PR TITLE
fix: Support classes where the constructor takes parameters

### DIFF
--- a/src/class-properties.ts
+++ b/src/class-properties.ts
@@ -33,7 +33,7 @@ export function Property(): PropertyDecorator {
  * @param targetClass - The class to list property names for.
  **/
 export function getClassProperties(targetClass: {
-  new (): Record<string, any>;
+  new (...args: any[]): Record<string, any>;
 }): string[] {
   return Reflect.getMetadata(KEY, targetClass.prototype) ?? [];
 }
@@ -52,7 +52,7 @@ export function getClassProperties(targetClass: {
  **/
 export function hasProperty(
   targetClass: {
-    new (): Record<string, any>;
+    new (...args: any[]): Record<string, any>;
   },
   propertyName: string,
 ): boolean {
@@ -78,7 +78,7 @@ export function hasProperty(
  */
 export function compareProperties(
   object: Record<string, any>,
-  templateClass: { new (): Record<string, any> },
+  templateClass: { new (...args: any[]): Record<string, any> },
 ): {
   missing: string[];
   extra: string[];
@@ -111,7 +111,7 @@ export function compareProperties(
  */
 export function hasValidProperties(
   object: Record<string, any>,
-  templateClass: { new (): Record<string, any> },
+  templateClass: { new (...args: any[]): Record<string, any> },
 ): boolean {
   const comparison = compareProperties(object, templateClass);
   return comparison.missing.length == 0 && comparison.extra.length == 0;

--- a/test/class-properties.spec.ts
+++ b/test/class-properties.spec.ts
@@ -17,6 +17,32 @@ describe('tests Property decorator', () => {
     expect(properties).toEqual(['field']);
   });
 
+  it('tests getting properties of a class with a constructor', async () => {
+    class Test {
+      @Property()
+      field!: string;
+
+      constructor() {}
+    }
+
+    const properties = getClassProperties(Test);
+    expect(properties).toEqual(['field']);
+  });
+
+  it('tests getting properties of a class with a constructor that has parameters', async () => {
+    class Test {
+      @Property()
+      field!: string;
+
+      constructor(param: string) {
+        this.field = param;
+      }
+    }
+
+    const properties = getClassProperties(Test);
+    expect(properties).toEqual(['field']);
+  });
+
   it('tests getting properties of a class with no decorator', async () => {
     class Test {
       field!: string;

--- a/test/class-properties.spec.ts
+++ b/test/class-properties.spec.ts
@@ -22,7 +22,9 @@ describe('tests Property decorator', () => {
       @Property()
       field!: string;
 
-      constructor() {}
+      constructor() {
+        this.field = 'test';
+      }
     }
 
     const properties = getClassProperties(Test);


### PR DESCRIPTION
This adjusts the parameters of `getClassProperties`, `hasProperty`, `compareProperties` and `hasValidProperties` so that they can accept classes where the constructors take parameters.

Closes #210 